### PR TITLE
documentation link for gh-pages site

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,6 +40,9 @@ CrowNet is based on a number of other software components which are developed by
 
 We would like to thank all organizations and individuals involved for making these great projects publicly available. Without these, CrowNet could not be implemented.
 
+### Documentation
+The documentation can be found in our [Github project](https://sam-dev.cs.hm.edu/rover/crownet/-/tree/master/doc/README.md)
+
 ### Contributions
 
 We welcome contributions from anyone, who is interested in extending or improving the software framework. Please submit a pull-request via github.


### PR DESCRIPTION
**Note:**
* Wiki migration to repository needs to be completed and mirrored to github first