### PR TITLE
Fix user home mount and use $HOME variable

### DIFF
--- a/config/USER_ENV.config
+++ b/config/USER_ENV.config
@@ -4,7 +4,7 @@
 
 # Set addional mount point for container neede during execution. 
 # For instance for large hdd for results 
-# export OPP_EXTERNAL_DATA_MNT="/src/path:/target/path:rw"
+# export OPP_EXTERN_DATA_MNT="/src/path:/target/path:rw"
 
 
 

--- a/scripts/lib/lib.sh
+++ b/scripts/lib/lib.sh
@@ -149,7 +149,7 @@ function run_container_X11() {
 	if [[ "$OSTYPE" == "darwin"* ]]; then
 		CMD_ARR+=(--volume="/Users/$USER:/home/$USER")
 	else
-		CMD_ARR+=(--volume="/home/$USER:/home/$USER")
+		CMD_ARR+=(--volume="$HOME:/$HOME")
 	fi
 	if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		CMD_ARR+=(--volume="/etc/group:/etc/group:ro")


### PR DESCRIPTION
Assuming the that the user $HOME is under `/home` does not work for the root user or non standard installations.  Using $HOME variable instead.